### PR TITLE
String to Int64 validation with luhn algorithm

### DIFF
--- a/CCValidator/Classes/CCValidator.swift
+++ b/CCValidator/Classes/CCValidator.swift
@@ -216,7 +216,7 @@ public extension CCValidator {
     }
     
     private class func validateWithLuhnAlgorithm(creditCardNumber number: String) -> Bool {
-        guard let _ = Int(number) else {
+        guard let _ = Int64(number) else {
             //if string is not convertible to int, return false
             return false
         }


### PR DESCRIPTION
On a device such as iPhone 4s, Int is a 32-bit integer.
64-bit integer needs to be declared explicitly with Int64.

Otherwise validation always fails with luhn algorithm on iPhone 4s.